### PR TITLE
DX-1246: Added proposal for paginated content usage

### DIFF
--- a/apps/client-test-app/index.js
+++ b/apps/client-test-app/index.js
@@ -43,11 +43,35 @@ app.get('/', async (req, res) => {
   }
   const api = miro.as(USER_ID)
 
-  let body = '<h1>All boards you have access to</h1><ul>'
-  for await (const board of api.getAllBoards()) {
+  const page = req.query.page || 1
+  const boardsPerPage = 10
+
+  let body = `<h1>Boards you have access to (page ${page})</h1><ul>`
+  const boards = await api.getBoardsPaginated({
+    teamId: '3458764515148204448',
+    limit: boardsPerPage.toString(),
+    offset: (page - 1) * boardsPerPage,
+  })
+
+  for (const board of boards.body.data) {
     body += `<li><a href="boards/${board.id}">${board.name} (${board.id})</a></li>`
   }
-  body += '</ul>'
+  body += `</ul>`
+
+  const {total} = boards.body
+  const pages = Math.ceil(total / boardsPerPage)
+
+  if (pages > 1) {
+    body += `
+    <h2>Pages</h2>
+    <ul>
+        ${new Array(pages)
+          .fill(null)
+          .map((_, i) => `<li><a href="/?page=${i + 1}">${i + 1}</a></li>`)
+          .join('')}
+    </ul>
+    `
+  }
 
   res.send(body)
 })

--- a/packages/typescript-node/highlevel/Api.ts
+++ b/packages/typescript-node/highlevel/Api.ts
@@ -39,4 +39,11 @@ export abstract class Api {
       currentOffset += size
     }
   }
+
+  async getBoardsPaginated(query?: Parameters<MiroApi['getBoards']>[0]) {
+    const boardsResponse = await this._api.getBoards(query)
+    boardsResponse?.body?.data?.map((board) => new Board(this._api, board.id, board))
+
+    return boardsResponse
+  }
 }


### PR DESCRIPTION
When reading this explanation: when I say boards, it can be any item that has a getter.

I've thought about changing `getAllBoards` to return in batches (of say 10 boards), and calling `boards.next()` would return the next set (10 to 20). However: The method is called getALLboards. Thats why I think calling a new function `get[x]Paginated` is clearer. Then the user of the client can use the pagination options as they see fit. See example usage in `client-test-app`