### PR TITLE
DX-1366 Add links to Node.js reference docs to make them easier to discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ This repository contains Miro API clients and the tools needed to generate them,
 Currently, the only available client is the [Node.js client](./packages/miro-api), written in [TypeScript](https://www.typescriptlang.org/).
 
 Contribution to this project is open and welcome! Read our [CONTRIBUTING.md](./CONTRIBUTING.md) guidelines to get started. Thank you for your help!
+
+### Miro Node.js client
+
+- [Miro Node.js client reference documentation](https://miroapp.github.io/api-clients/index.html)

--- a/packages/miro-api/README.md
+++ b/packages/miro-api/README.md
@@ -1,4 +1,5 @@
 [Miro Node.js client reference documentation](https://miroapp.github.io/api-clients/index.html)
+
 ## Miro Node.js API client library
 
 The Miro Node.js API client is a JavaScript library that enables Miro REST API functionality in Miro apps based on Node.js.

--- a/packages/miro-api/README.md
+++ b/packages/miro-api/README.md
@@ -1,5 +1,4 @@
-[Miro Node.js API client reference documentation](https://miroapp.github.io/api-clients/classes/index.Miro.html)
-
+[Miro Node.js client reference documentation](https://miroapp.github.io/api-clients/index.html)
 ## Miro Node.js API client library
 
 The Miro Node.js API client is a JavaScript library that enables Miro REST API functionality in Miro apps based on Node.js.

--- a/packages/miro-api/docs/implement-storage.md
+++ b/packages/miro-api/docs/implement-storage.md
@@ -119,3 +119,9 @@ app.get('/', async (req, res) => {
   // ...
 }
 ```
+
+## See also
+
+- [`Miro` object reference documentation](https://miroapp.github.io/api-clients/classes/index.Miro.html)
+- [`MiroApi` object reference documentation](https://miroapp.github.io/api-clients/classes/index.MiroApi.html)
+- [`Storage` interface reference documentation](https://miroapp.github.io/api-clients/interfaces/index._internal_.Storage.html)

--- a/packages/miro-api/docs/quickstart-auth.md
+++ b/packages/miro-api/docs/quickstart-auth.md
@@ -249,3 +249,9 @@ app.get('/auth/miro/callback', async (req, res) => {
 
 app.listen(4000, () => console.log('Started server on http://127.0.0.1:4000'))
 ```
+
+## See also
+
+- [`Miro` object reference documentation](https://miroapp.github.io/api-clients/classes/index.Miro.html)
+- [`MiroApi` object reference documentation](https://miroapp.github.io/api-clients/classes/index.MiroApi.html)
+- [`Storage` interface reference documentation](https://miroapp.github.io/api-clients/interfaces/index._internal_.Storage.html)

--- a/packages/miro-api/docs/quickstart.md
+++ b/packages/miro-api/docs/quickstart.md
@@ -168,3 +168,9 @@ For more information about the methods that `Board` makes available, see the [re
 
 You can also start integrating your data into Miro. For example, add [sticky notes](https://miroapp.github.io/api-clients/classes/index._internal_.StickyNoteItem.html), create [app cards](https://miroapp.github.io/api-clients/classes/index._internal_.AppCardItem.html), and more. \
 For more inspiration, see the [example app to manage sticky notes and tags](https://github.com/miroapp/app-examples/tree/main/examples/node-stickies-csv) on our GitHub repo.
+
+## See also
+
+- [`Miro` object reference documentation](https://miroapp.github.io/api-clients/classes/index.Miro.html)
+- [`MiroApi` object reference documentation](https://miroapp.github.io/api-clients/classes/index.MiroApi.html)
+- [`Storage` interface reference documentation](https://miroapp.github.io/api-clients/interfaces/index._internal_.Storage.html)


### PR DESCRIPTION
* Add a "See also" section with links to the reference docs
* Add a left-side navigation link to the reference docs (done directly in ReadMe, so not part of this PR)