### PR TITLE
fix(miro-api): Set cursor to getAllOrganizationMembers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.1]
+
+- fixed cursor pagination for `getAllOrganizationMembers`
+
 ## [2.0.0]
 
 - added new experimental API endpoints and updated based on latest specification:

--- a/packages/miro-api/highlevel/Organization.ts
+++ b/packages/miro-api/highlevel/Organization.ts
@@ -1,6 +1,6 @@
 import {Organization} from '../model/organization'
 import {OrganizationMember, Team} from './index'
-import {MiroApi} from '../api'
+import {EnterpriseGetOrganizationMembers200Response, MiroApi} from '../api'
 
 /** @hidden */
 export abstract class BaseOrganization extends Organization {
@@ -18,7 +18,9 @@ export abstract class BaseOrganization extends Organization {
   ): AsyncGenerator<OrganizationMember, void> {
     let cursor: string | undefined = undefined
     while (true) {
-      const response = (await this._api.enterpriseGetOrganizationMembers(this.id.toString(), {...query, cursor})).body
+      const response: EnterpriseGetOrganizationMembers200Response = (
+        await this._api.enterpriseGetOrganizationMembers(this.id.toString(), {...query, cursor})
+      ).body
 
       for (const item of response.data || []) {
         yield new OrganizationMember(this._api, this.id, item.id, item)

--- a/packages/miro-api/highlevel/Organization.ts
+++ b/packages/miro-api/highlevel/Organization.ts
@@ -24,7 +24,8 @@ export abstract class BaseOrganization extends Organization {
         yield new OrganizationMember(this._api, this.id, item.id, item)
       }
 
-      if (!response.data?.length || !response.cursor) return
+      cursor = response.cursor
+      if (!response.data?.length || !cursor) return
     }
   }
 

--- a/packages/miro-api/package.json
+++ b/packages/miro-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mirohq/miro-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node.js client for the Miro REST API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`getAllOrganizationMembers` doesn't work pagination because it doesn't set a cursor.

The following sample code can reproduce the bug that loops the same output.

sample
```sample.ts
const {MiroApi} = require('@mirohq/miro-api')
const api = new MiroApi('Access Token')

const app = (async function () {
  const org = await api.getOrganization('org_id')
  for await (const member of await org.getAllOrganizationMembers()) {
    console.log(member)
  }
})()
```