### PR TITLE
Replace auto-merge action to `fastify/github-action-merge-dependabot`

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge
+name: Dependabot
 on: pull_request_target
 
 permissions:
@@ -6,11 +6,10 @@ permissions:
   contents: write
 
 jobs:
-  auto-merge:
+  Auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: fastify/github-action-merge-dependabot@v3
         with:
           target: minor
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          use-github-auto-merge: true


### PR DESCRIPTION
I replaced `ahmadnassri/action-dependabot-auto-merge` with another one because the previous one uses the command `@dependabot/merge` which can't be posted by the GitHub Actions bot. So, it requires a personal token to be used, which isn't a good idea for enterprise projects due to variable team composition. Unlike that, the new action uses the GitHub Auto-merge feature, which requires only the default GITHUB_TOKEN and enabling the Auth-merge feature in settings.

I've tested the new action on my personal project and it works as expected:

<img width="707" alt="image" src="https://github.com/miroapp/api-clients/assets/1961590/d857da9d-bcdf-41f9-96c4-454e8a0512b5">
