### PR TITLE
Fix workflow cache and revert prettier update

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -31,11 +31,15 @@ jobs:
       # setup
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Pages
         uses: actions/configure-pages@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'yarn'
+
       - run: yarn
         working-directory: packages/miro-api
 
@@ -48,6 +52,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: "packages/miro-api/docs-out/"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'yarn'
 
       - run: yarn
         working-directory: packages/miro-api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,23 +17,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-
-      # Speed up subsequent runs with caching
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-              ${{ runner.os }}-
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest": "^29.6.2",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "prettier": "^3.0.1",
+    "prettier": "^2.8.7",
     "tsx": "^3.12.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,10 +3897,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
 
-prettier@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.1.tgz#65271fc9320ce4913c57747a70ce635b30beaa40"
-  integrity sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==
+prettier@^2.8.7:
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
+  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
 
 pretty-format@^29.0.0, pretty-format@^29.6.2:
   version "29.6.2"


### PR DESCRIPTION
An update from prettier v2 to v3 has been auto-merged, even though the new version broke generator tests. The update error wasn't discovered in the PR workflow, because obsolete npm cache. The mistake was in the cache key, based on missing `package-lock.json` file. The issue has been fixed by switching to the integrated cache in `actions/setup-node@v3`.