### PR TITLE
Fix the wrong revision for the `test` workflow checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+
   workflow_dispatch:
-  pull_request_target:
-    branches: [main]
+
+  pull_request:
+    branches: [ main ]
 
 permissions:
   pull-requests: write
@@ -26,18 +28,20 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: run tests
+      - name: Run tests
         run: yarn coverage
 
       - name: Coverage Report as Comment (Clover)
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        # Skip the step for PRs from forks, because GitHub doesn't
+        # provide `write` permissions for changes from forks
+        if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'miroapp' }}
         uses: lucassabreu/comment-coverage-clover@main
         with:
           file: packages/miro-api/coverage/clover.xml
 
-      - name: test generator
+      - name: Test generator
         run: yarn workspace generator run validate_commited
 
-      - name: test build
+      - name: Test build
         run: yarn && yarn build
         working-directory: packages/miro-api

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest": "^29.6.2",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "prettier": "^3.0.2",
+    "prettier": "^2.8.7",
     "tsx": "^3.12.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,10 +3898,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
 
-prettier@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.2.tgz#78fcecd6d870551aa5547437cdae39d4701dca5b"
-  integrity sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==
+prettier@^2.8.7:
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
+  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
 
 pretty-format@^29.0.0, pretty-format@^29.6.2:
   version "29.6.2"


### PR DESCRIPTION
The issue appeared because `pull_request_target` uses the PR base branch as `GITHUB_REF`: https://github.com/actions/checkout/issues/518. In the issue, they offer to use a merged revision implicitly. But that enables stealing secrets from the repo: https://blog.gitguardian.com/github-actions-security-cheat-sheet/#be-extra-careful-with-the-pullrequesttarget-trigger.

Currently, the `pull_request_target` trigger is used in the `test` workflow to enable adding a coverage report comment to the PR based on fork repos.

There is a solution in GitHub docs to leave a comment, but it seems to be an over-engineering: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow. The easiest way just to disable creating the comment for PRs from forks.