### PR TITLE
Fix dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,5 @@
 name: Dependabot
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
`fastify/github-action-merge-dependabot` filters out PRs triggered not by `pull_request` event. After creating a ticket to the action repo, developers answered me that probably there is no need to use `pull_request_target`: https://github.com/fastify/github-action-merge-dependabot/pull/474#pullrequestreview-1611390215.

And it seems we don't: the workflow is targeted on dependabot PRs only, which are internal (not from forked repos), so for the `pull_request` event the workflow will have all required write permissions.