### PR TITLE
DX-2941 Allow accessing oneOf model fields directly

### DIFF
--- a/packages/generator/python-template/model_oneof.mustache
+++ b/packages/generator/python-template/model_oneof.mustache
@@ -48,6 +48,9 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             super().__init__(**kwargs)
 
+    def __getattr__(self, attr: str):
+        return getattr(self.actual_instance, attr)
+
     @field_validator('actual_instance')
     def actual_instance_must_validate_oneof(cls, v):
         {{#isNullable}}

--- a/packages/miro-api-python/miro_api/models/enterprise_get_organization_members200_response.py
+++ b/packages/miro-api-python/miro_api/models/enterprise_get_organization_members200_response.py
@@ -69,6 +69,9 @@ class EnterpriseGetOrganizationMembers200Response(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    def __getattr__(self, attr: str):
+        return getattr(self.actual_instance, attr)
+
     @field_validator("actual_instance")
     def actual_instance_must_validate_oneof(cls, v):
         instance = EnterpriseGetOrganizationMembers200Response.model_construct()

--- a/packages/miro-api-python/miro_api/models/mindmap_widget_data_output.py
+++ b/packages/miro-api-python/miro_api/models/mindmap_widget_data_output.py
@@ -54,6 +54,9 @@ class MindmapWidgetDataOutput(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    def __getattr__(self, attr: str):
+        return getattr(self.actual_instance, attr)
+
     @field_validator("actual_instance")
     def actual_instance_must_validate_oneof(cls, v):
         instance = MindmapWidgetDataOutput.model_construct()

--- a/packages/miro-api-python/miro_api/models/subscription_data.py
+++ b/packages/miro-api-python/miro_api/models/subscription_data.py
@@ -54,6 +54,9 @@ class SubscriptionData(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    def __getattr__(self, attr: str):
+        return getattr(self.actual_instance, attr)
+
     @field_validator("actual_instance")
     def actual_instance_must_validate_oneof(cls, v):
         instance = SubscriptionData.model_construct()

--- a/packages/miro-api-python/miro_api/models/widget_data_output.py
+++ b/packages/miro-api-python/miro_api/models/widget_data_output.py
@@ -112,6 +112,9 @@ class WidgetDataOutput(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    def __getattr__(self, attr: str):
+        return getattr(self.actual_instance, attr)
+
     @field_validator("actual_instance")
     def actual_instance_must_validate_oneof(cls, v):
         instance = WidgetDataOutput.model_construct()

--- a/packages/miro-api-python/miro_api/models/widget_data_output_platform.py
+++ b/packages/miro-api-python/miro_api/models/widget_data_output_platform.py
@@ -112,6 +112,9 @@ class WidgetDataOutputPlatform(BaseModel):
         else:
             super().__init__(**kwargs)
 
+    def __getattr__(self, attr: str):
+        return getattr(self.actual_instance, attr)
+
     @field_validator("actual_instance")
     def actual_instance_must_validate_oneof(cls, v):
         instance = WidgetDataOutputPlatform.model_construct()


### PR DESCRIPTION
Instead of devs having to access oneOf models through `.actual_instance` attribute, we expose it directly on the parent model.

Example of previous code with `WidgetData` model:
```python
item = api.get_items('board_id').data[0]
print(item.data.actual_instance.content)
```
now it can be simpler:
```python
item = api.get_items('board_id').data[0]
print(item.data.content) # don't need to access actual_instance
```