### PR TITLE
Fix missing poetry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-          cache: 'poetry'
+
+      - run: pip install poetry
 
       - name: Build the packages
         run: poetry build


### PR DESCRIPTION
I assumed that setup-python would also install poetry but it doesn't so we install it with pip explicitly