### PR TITLE
CADE-482 Fix job 'Upgrade api-specification' fails in api-clients

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: '3.9'
 
-      - run: pip install poetry
+      - run: pip install poetry~=1.8.5
 
       # install requirements
       - run: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: '3.9'
 
-      - run: pip install poetry
+      - run: pip install poetry~=1.8.5
 
       - name: Build the packages
         run: poetry build


### PR DESCRIPTION
A breaking change was introduced in the dependency "poetry" v2. To fix it explicit versions of the dependency were specified in the workflows