### PR TITLE
Announce retirement of public API client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 > - The existing published packages will remain available but will receive no further updates.
 > - We will continue to maintain and update the [OpenAPI specification](./spec.json), so you can generate your own clients using tools like [OpenAPI Generator](https://openapi-generator.tech/) or [openapi-ts](https://github.com/hey-api/openapi-ts).
 > - We recommend migrating to a self-generated or custom client before the retirement date.
->
+> - If you are an enterprise customer and you have additional questions please reach out to your Customer Support Representive
+> 
 > Thank you to everyone who contributed to and used these clients.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 ## Miro API clients
 
+> **⚠️ Retirement Notice**
+>
+> The Miro API client libraries in this repository are being retired. **No new versions of these clients will be published after November 1, 2026.**
+>
+> Given the rapidly changing AI landscape, we believe it is better for every organization to implement their own clients tailored to their specific needs, rather than maintaining a single public client library.
+>
+> **What this means for you:**
+> - The existing published packages will remain available but will receive no further updates.
+> - We will continue to maintain and update the [OpenAPI specification](./spec.json), so you can generate your own clients using tools like [OpenAPI Generator](https://openapi-generator.tech/) or [openapi-ts](https://github.com/hey-api/openapi-ts).
+> - We recommend migrating to a self-generated or custom client before the retirement date.
+>
+> Thank you to everyone who contributed to and used these clients.
+
+---
+
 This repository contains Miro API clients and the tools needed to generate them, based on the OpenAPI specification (OAS).
 Currently, we have a [Node.js client](./packages/miro-api), written in [TypeScript](https://www.typescriptlang.org/) and a [Python client](https://github.com/miroapp/api-clients/tree/main/packages/miro-api-python)
 


### PR DESCRIPTION
## Summary

- Adds a prominent retirement notice to the README announcing that no new versions of the client libraries will be published after **November 1, 2026** (6 months from May 1, 2026).
- Explains the rationale: given the changing AI landscape, organizations are better served by generating/implementing their own clients.
- Notes that the OpenAPI specification will continue to be maintained and updated.

## Test plan

- [ ] Review the README renders correctly on GitHub
- [ ] Confirm retirement date (November 1, 2026) is accurate
- [ ] Confirm messaging/tone is appropriate for public announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)