### PR TITLE
CADE-2516 Repoint high-level tokenInfo to renamed get-access-token-context op

### DIFF
--- a/packages/generator/modelDefinition.ts
+++ b/packages/generator/modelDefinition.ts
@@ -13,15 +13,20 @@ const MODELS = {
         alias: 'getOrganization',
         returns: 'Organization',
       },
-      {method: 'tokenInfo', returns: 'TokenInformation'},
+      {method: 'getAccessTokenContext', alias: 'tokenInfo', returns: 'TokenInformation'},
     ],
   },
 
+  // The OAuth token-context operation was renamed in the spec from `token-info`
+  // to `get-access-token-context` (and its schema from `TokenInformation` to
+  // `TokenContext`). Keep the public high-level surface (`api.tokenInfo()`
+  // returning `TokenInformation`) backward-compatible via the method alias and
+  // by extending the regenerated low-level `TokenContext` model.
   TokenInformation: {
     props: [],
     extendedModel: {
-      name: 'TokenInformation',
-      path: '../model/tokenInformation',
+      name: 'TokenContext',
+      path: '../model/tokenContext',
     },
     methods: [],
   },


### PR DESCRIPTION
## What & why

The `api-specification` spec renamed the OAuth token-context operation from `token-info` to `get-access-token-context` (and its schema `TokenInformation` → `TokenContext`) so the ReadMe reference page slug matches the original `/reference/get-access-token-context` URL (see api-specification [#402](https://github.com/miroapp-dev/api-specification/pull/402), [CADE-2516](https://miro.atlassian.net/browse/CADE-2516)).

That removed the generated `tokenInfo` method and `TokenInformation` low-level model the high-level generator depends on, so `yarn build` crashed in `highlevelModelGenerator` (`MiroApi.prototype['tokenInfo']` is `undefined`). This is why the `api-specification` `publish_public_repo` job started failing.

## Change

Repoint the high-level model config (`packages/generator/modelDefinition.ts`) to the new names while keeping the **public SDK surface unchanged**:

```ts
{method: 'getAccessTokenContext', alias: 'tokenInfo', returns: 'TokenInformation'}
// + the high-level TokenInformation model now extends the regenerated low-level `TokenContext`
```

- `method` → `getAccessTokenContext` (the new low-level method)
- `alias` → `tokenInfo` (so `api.tokenInfo()` still works for SDK users)
- the high-level `TokenInformation` class is preserved, now extending the generated `TokenContext`

`api.tokenInfo(): Promise<TokenInformation>` is therefore unchanged for consumers — only its internal wiring to the generated client changes.

## Scope

This is the only hand-written source change needed. The full client regeneration (low-level `api/`, `model/`, `highlevel/index.ts`, `spec.json`) lands automatically via the `publish_public_repo` upgrade PR once this is on `main` and the job is re-run.

## Verification

- `yarn workspace generator test` passes.
- Ran the full `yarn build` locally against the new `spec.json` + this config: the Node high-level generator no longer crashes and emits `tokenInfo()` calling `this._api.getAccessTokenContext()`.